### PR TITLE
Fix path for frontend env values

### DIFF
--- a/chart/templates/krateo-installer.yaml
+++ b/chart/templates/krateo-installer.yaml
@@ -812,9 +812,9 @@ spec:
             value: https://$KRATEO_BFF_INGRESS_HOST
           {{- else if .Values.krateoplatformops.frontend.overrideconf }}
           - name: env.AUTHN_API_BASE_URL
-            value: {{ .Values.krateoplatformops.ingress.frontend.env.AUTHN_API_BASE_URL }}
+            value: {{ .Values.krateoplatformops.frontend.env.AUTHN_API_BASE_URL }}
           - name: env.BFF_API_BASE_URL
-            value: {{ .Values.krateoplatformops.ingress.frontend.env.BFF_API_BASE_URL }}
+            value: {{ .Values.krateoplatformops.frontend.env.BFF_API_BASE_URL }}
           {{- end }}
 
     - id: install-core-provider


### PR DESCRIPTION
The path used to get frontend env values from helm values is wrong.
The values file set those values under .Values.krateoplatformops.frontend.env and not .Values.krateoplatformops.ingress.frontend.env

It affects latest version 0.1.71 of the chart.