### PR TITLE
Add support for overriding OPA MGMT image repository in installer chart

### DIFF
--- a/chart/templates/krateo-installer.yaml
+++ b/chart/templates/krateo-installer.yaml
@@ -6045,7 +6045,19 @@ spec:
           - name: image.tag
             value: {{ .Values.krateoplatformops.opa.image.tag }}
           {{- end }}
-          {{- if .Values.krateoplatformops.opa.env }}
+          {{- if .Values.krateoplatformops.opa.mgmt.image.repository }}
+          - name: mgmt.image.repository
+            value: {{ .Values.krateoplatformops.opa.mgmt.image.repository }}
+          {{- end }}
+          {{- if .Values.krateoplatformops.opa.mgmt.image.pullPolicy }}
+          - name: mgmt.image.pullPolicy
+            value: {{ .Values.krateoplatformops.opa.mgmt.image.pullPolicy }}
+          {{- end }}
+          {{- if .Values.krateoplatformops.opa.mgmt.image.tag }}
+          - name: mgmt.image.tag
+            value: {{ .Values.krateoplatformops.opa.mgmt.image.tag }}
+          {{- end }}
+          {{- if .Values.krateoplatformops.opa.env }}          
           {{- range $key, $value := .Values.krateoplatformops.opa.env }}
           - name: env.{{ $key }}
             value: {{ $value | quote }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -882,3 +882,8 @@ krateoplatformops:
     service: 
       annotations: {}
     env: {}
+    mgmt:
+      image:
+        repository: ghcr.io/krateoplatformops/kube-mgmt
+        pullPolicy: IfNotPresent
+        tag: "9.0.1"


### PR DESCRIPTION
This PR introduces the ability to override the OPA MGMT image repository when deploying Krateo with the installer chart.

Previously, the chart did not expose a configurable parameter for opa.mgmt.image.repository. As a result, in environments without direct Internet access, the OPA component attempted to pull its image from the public registry, leading to ImagePullBackOff errors.

With this change, users can now set the parameter:
```
krateoplatformops:
  opa:
    mgmt:
      image:
        repository: <custom-registry>/opa-mgmt
```
directly in their values.yaml, ensuring compatibility with private or proxy registries (e.g., Nexus, Artifactory, Harbor).

**Changes**

- Added krateoplatformops.opa.mgmt.image.repository parameter to installer chart values.
- Updated chart templates to use this value when defined.

**Expected Behavior**

- Users deploying in restricted environments can override the OPA MGMT image repository.
- The OPA pods pull the image from the configured registry instead of ghcr.io.