### PR TITLE
fix: add a default appVersion as APP_VERSION is not a valid tag

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -21,7 +21,7 @@ version: CHART_VERSION
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: APP_VERSION
+appVersion: 0.6.2
 
 dependencies:
   - name: installer-crd


### PR DESCRIPTION
If APP_VERSION is specified as appVersion, by default the installer image tag is APP_VERSION which doesn't exist and this cause a POD ImagePullBackoff error.